### PR TITLE
fixed href order heading in navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
       <div class="collapse navbar-collapse" id="navbarNavDropdown">
         <div class="navbar-nav ms-auto">
           <a class="nav-link" href="home.html">Home</a>
-          <a class="nav-link active" href=index.html">Order</a>
+          <a class="nav-link active" href="index.html">Order</a>
           <a class="nav-link" href="fidget.html">Fidgets</a>
           <a class="nav-link" href="utility.html">Utility</a>
           <a class="nav-link" href="other.html">Other</a>


### PR DESCRIPTION
If you clicked the order heading in the navbar, it would lead you to _index.html_***"***, which is not a valid page. I fixed this by changing it to _index.html_.